### PR TITLE
feat: stop sending user and reaction for reactions

### DIFF
--- a/api/main.go
+++ b/api/main.go
@@ -86,9 +86,7 @@ func main() {
 
 					v.WriteJSON(map[string]interface{}{
 						"type":    "reaction",
-						"emoji":   ev.Reaction,
 						"channel": ev.Item.Channel,
-						"user":    ev.User,
 					})
 
 					mutex.Unlock()


### PR DESCRIPTION
Is there a reason that we need to send these? If we don't need them for anything we should not send them so nobody gets upset (it is also just kinda a waste). @rishiosaur are you using these for anything?

Signed-off-by: Matt Gleich <git@mattglei.ch>